### PR TITLE
Fixing the parse to Boolean from string

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ function parseKey(value, key) {
   }
 
   // Boolean
-  if (value.toLowerCase() === 'true' || value.toLowerCase() === 'false') {
+  if (value.toString().toLowerCase() === 'true' || value.toString().toLowerCase() === 'false') {
     debug(`key ${key} parsed as a Boolean`);
     return value === 'true';
   }


### PR DESCRIPTION
When for some reason, the value is not string, and the boolean parser evaluates it, is getting an error, to fix it, the value is transformed to string to correctly evaluation